### PR TITLE
Update documentation to point at the github repo

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,9 +2,9 @@ To install do::
 
     $ easy_install vdm
 
-Or checkout from our mercurial repository::
+Or checkout from our git repository::
 
-    $ hg clone http://knowledgeforge.net/okfn/vdm
+    $ git clone https://github.com/okfn/vdm
 
 For more information see the main package docstring. To view this either just
 open vdm/__init__.py or do (after installation)::

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license = "MIT",
     keywords = "versioning sqlobject sqlalchemy orm",
     url = "http://www.okfn.org/vdm/", 
-    download_url = "http://knowledgeforge.net/okfn/vdm",
+    download_url = "https://github.com/okfn/vdm",
     zip_safe = False,
     classifiers = [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
The previous location doesn't appear to be being updated.
