### PR TITLE
Code changes to support SQLAlchemy 0.9

### DIFF
--- a/vdm/sqlalchemy/base.py
+++ b/vdm/sqlalchemy/base.py
@@ -405,7 +405,12 @@ def create_object_version(mapper_fn, base_object, rev_table):
     # If related object is revisioned then can do all of these
     # If not revisioned can only support simple relation (first case -- why?)
     for prop in base_mapper.iterate_properties:
-        is_relation = prop.__class__ == sqlalchemy.orm.properties.PropertyLoader
+        try:
+            is_relation = prop.__class__ == sqlalchemy.orm.properties.PropertyLoader
+        except AttributeError:
+            # SQLAlchemy 0.9
+            is_relation = prop.__class__ == sqlalchemy.orm.properties.RelationshipProperty
+
         if is_relation:
             # in sqlachemy 0.4.2
             # prop_remote_obj = prop.select_mapper.class_

--- a/vdm/sqlalchemy/test_demo_misc.py
+++ b/vdm/sqlalchemy/test_demo_misc.py
@@ -9,7 +9,8 @@ class TestMisc:
         repo.rebuild_db()
 
     def test_column_create(self):
-        if sqav.startswith("0.6") or sqav.startswith("0.7"):
+
+        if sqav[:3] in ("0.6", "0.7", "0.8", "0.9"):
             ## FIXME???
             ## This test does not appear to test anything that is
             ## VDM specific. It also fails with SQLAlchemy 0.6

--- a/vdm/sqlalchemy/tools.py
+++ b/vdm/sqlalchemy/tools.py
@@ -22,7 +22,8 @@ if sqav[:3] in ("0.4", "0.5"):
                            " CASCADE")
                self.execute()
      postgres.dialect.schemadropper = CascadeSchemaDropper
-elif sqav.startswith("0.6") or sqav.startswith("0.7") or sqav.startswith("0.8"):
+
+elif sqav[:3] in ("0.6", "0.7", "0.8", "0.9"):
      from sqlalchemy.dialects.postgresql import base
      def visit_drop_table(self, drop):
           return "\nDROP TABLE " + \


### PR DESCRIPTION
Apart from some version checking, the only change has been the use of
`sqlalchemy.orm.properties.RelationshipProperty` instead of
`sqlalchemy.orm.properties.PropertyLoader`.

Apparently `PropertyLoader` was renamed to `RelationProperty` in SA
0.5 [1](!), which in turn got renamed to `RelationshipProperty`.

[1] https://github.com/zzzeek/sqlalchemy/blob/1abd53a3556b9593d9eba868d69c13bae3c3a7ab/doc/build/changelog/changelog_05.rst
